### PR TITLE
translations of named routes by name (not path)

### DIFF
--- a/lib/i18n_routing_rails2.rb
+++ b/lib/i18n_routing_rails2.rb
@@ -99,7 +99,8 @@ module ActionController
           @locales.each do |l|
             I18n.locale = l
             nt = "#{l}_#{name}"
-            if nt != name and (t = I18nRouting.translation_for(path, :named_routes_path))
+            t = I18nRouting.translation_for(name, :named_routes) || I18nRouting.translation_for(path, :named_routes_path)
+            if nt != name and t
               gl_add_named_route(nt, t, options.merge(:glang => l))
               puts("[I18n] > localize %-10s: %40s (%s) => %s" % ['route', name, l, t]) if @i18n_verbose
             end

--- a/lib/i18n_routing_rails3.rb
+++ b/lib/i18n_routing_rails3.rb
@@ -294,7 +294,12 @@ module I18nRouting
       I18n.locale = locale
       ts = @path.gsub(/^\//, '')
       ts.gsub!('(.:format)', '')
-      @localized_path = (@scope[:path] || '/') + (!ts.blank? ? (I18nRouting.translation_for(ts, :named_routes_path) || ts) : '')
+      
+      tp = @options[:as] && I18nRouting.translation_for(@options[:as], :named_routes) || 
+          !ts.blank? && I18nRouting.translation_for(ts, :named_routes_path) || ''
+        
+      
+      @localized_path = (@scope[:path] || '/') + tp
 
       # If a translated path exists, set localized infos
       if @localized_path and @localized_path != @path

--- a/spec/i18n_routing/i18n_spec.rb
+++ b/spec/i18n_routing/i18n_spec.rb
@@ -16,6 +16,7 @@ describe :localized_routes do
 
           map.localized(I18n.available_locales, :verbose => false) do
             map.about 'about', :controller => 'about', :action => :show
+            map.welcome 'welcome/to/our/page', :controller => :welcome, :action => :index
             
             map.resources :users, :member => {:level => :get, :one => :get, :two => :get}, :collection => {:groups => :get}
             map.resource  :contact
@@ -60,6 +61,7 @@ describe :localized_routes do
 
           localized(I18n.available_locales, :verbose => false) do
             match 'about' => "about#show", :as => :about
+            match 'welcome/to/our/page' => "welcome#index", :as => :welcome
 
             scope '/:locale', :constraints => { :locale => /[a-z]{2}/ } do
               match '/' => "about#show", :as => :localized_root
@@ -137,6 +139,7 @@ describe :localized_routes do
 
     it "named_route uses default values" do
       routes.send(:about_path).should == "/about"
+      routes.send(:welcome_path).should == '/welcome/to/our/page'
     end
 
     it "resource generates routes using default values" do
@@ -180,6 +183,16 @@ describe :localized_routes do
     it "named_route generates route using localized values" do
       routes.send(:about_path).should == "/#{I18n.t :about, :scope => :named_routes_path}"
     end
+    
+    it "named_route generated route from actual route name" do
+      I18n.locale = :en
+      routes.send(:welcome_path).should == "/#{I18n.t :welcome, :scope => :named_routes}"        
+      I18n.locale = :fr
+    end
+    
+    it "named_route generates route from route path when route name  not available" do
+      routes.send(:welcome_path).should == "/#{I18n.t 'welcome/to/our/page', :scope => :named_routes_path}"
+    end 
 
     it "named_route generates route using localized values and I18n.locale as a string" do
       o = I18n.locale

--- a/spec/locales/en.yml
+++ b/spec/locales/en.yml
@@ -11,3 +11,5 @@ en:
     contact: 'contact-us'
   named_routes_path:
     about: 'about-our-company'
+  named_routes:
+    welcome: 'welcome-to-our-page'

--- a/spec/locales/fr.yml
+++ b/spec/locales/fr.yml
@@ -27,6 +27,7 @@ fr:
     contact: 'contactez-nous'
   named_routes_path:
     about: 'a-propos'
+    'welcome/to/our/page': 'bienvenue/sur/notre/site' # no idea about french translation ;-) --R
   path_names:
     new: 'nouveau'
     edit: 'edition'


### PR DESCRIPTION
Hi all,

I've added the option to match the route translation for named routes by their name and not the path. I found it a little cumbersome for a project with existing routes to add all of them by their path and not the actual route name. Routes may change a lot during development, but the name usually does not.

Example:
    # routes.rb
    ActionController::Routing::Routes.draw do |map|
      map.localized do
        map.welcome 'welcome/to/our/page', :controller => 'welcome', :action => 'index'
      end
    end

```
# locales
en:
  named_routes:
    welcome: 'welcome-to-our-page'

fr:
  named_routes_path:
    'welcome/to/our/page': 'bienvenue'
```

The defaults still apply. When a named route can't be found in :named_routes then look for it in :named_routes_path. The example above shows the case for :en, when a named route is present, as well as for :fr, when named_routes_path is defined.

Best,
Rudi
